### PR TITLE
feature-holo-cli-address-argument

### DIFF
--- a/holo-cli/src/main.rs
+++ b/holo-cli/src/main.rs
@@ -145,11 +145,26 @@ fn main() {
                 .help("Execute argument as command")
                 .multiple(true),
         )
+        .arg(
+            Arg::with_name("address")
+                .short("a")
+                .long("address")
+                .value_name("ADDRESS")
+                .help("Holo daemon IPv4/6 address: http://IP:Port")
+                .multiple(true),
+        )
         .get_matches();
+
+    let _addr = matches.value_of("address");
+    let addr = match _addr {
+        Some(addr) => addr,
+        None => "http://[::1]:50051"
+    };
+    let grpc_addr: &'static str = Box::leak(addr.to_string().into_boxed_str());
 
     // Initialize YANG context and gRPC client.
     let mut yang_ctx = yang::new_context();
-    let mut client = GrpcClient::connect("http://[::1]:50051")
+    let mut client = GrpcClient::connect(grpc_addr)
         .expect("Failed to connect to holod");
     client.load_modules(&mut yang_ctx);
     YANG_CTX.set(Arc::new(yang_ctx)).unwrap();


### PR DESCRIPTION
A new argument "address" was added for holo-cli to give the ability to the user to choose the address of holo-daemon which can be on the local or remote machine with either of IPv4 or IPv6 address.

Using this feature you can give the exact address of holod. 
use holo-cli like the below:

```
holo-cli --address http://127.0.0.1:50051
```

![image](https://github.com/rwestphal/holo/assets/18419308/ba160ab1-5966-41af-9617-b9fcbb691372)

![image](https://github.com/rwestphal/holo/assets/18419308/3b3cb915-29b5-4ac4-b053-69830c31ec66)

![image](https://github.com/rwestphal/holo/assets/18419308/a2fba052-f47f-456c-b676-df45dcc79964)

