### PR TITLE
feature-holo-cli-address-argument

### DIFF
--- a/holo-cli/src/main.rs
+++ b/holo-cli/src/main.rs
@@ -144,12 +144,26 @@ fn main() {
                 .value_name("COMMAND")
                 .help("Execute argument as command")
                 .multiple(true),
+            )
+        .arg(
+            Arg::with_name("address")
+                .short("a")
+                .long("address")
+                .value_name("ADDRESS")
+                .help("Holo daemon IPv4/6 address: http://IP:Port")
+                .multiple(false),
         )
         .get_matches();
-
-    // Initialize YANG context and gRPC client.
-    let mut yang_ctx = yang::new_context();
-    let mut client = GrpcClient::connect("http://[::1]:50051")
+    
+        let addr = matches
+            .value_of("address")
+            .unwrap_or("http://[::1]:50051")
+            .to_string();
+        let grpc_addr: &'static str = Box::leak(addr.into_boxed_str());
+    
+        // Initialize YANG context and gRPC client.
+        let mut yang_ctx = yang::new_context();
+        let mut client = GrpcClient::connect(grpc_addr)
         .expect("Failed to connect to holod");
     client.load_modules(&mut yang_ctx);
     YANG_CTX.set(Arc::new(yang_ctx)).unwrap();


### PR DESCRIPTION
holo-cli: ‘address’ option to specify the holod address

A new argument "address" was added for holo-cli to give the ability to
the user to choose the address of holo-daemon which can be on the local
or remote machine with either of IPv4 or IPv6 address.
Using this feature you can give the exact address of holod.
The following formats are acceptable:

```
- holo-cli --address http://127.0.0.1:50051
- holo-cli -a http://127.0.0.1:50051
- cargo run -- --address http://127.0.0.1:50051
```
Signed-off-by: Rasoul Mesghali [rasoul.mesghali@gmail.com](mailto:rasoul.mesghali@gmail.com)